### PR TITLE
Remove line where the omniauth provider is added manually

### DIFF
--- a/config/initializers/omniauth_idcat_mobil.rb
+++ b/config/initializers/omniauth_idcat_mobil.rb
@@ -7,5 +7,3 @@ Devise.setup do |config|
                   ENV["IDCAT_MOBIL_SITE_URL"],
                   scope: :autenticacio_usuari
 end
-
-Decidim::User.omniauth_providers << :idcat_mobil


### PR DESCRIPTION
When upgrading to decidim v0.21, the omniauth provider is added automatically when setting it, so it is not necessary to add it manually anymore (it causes an error due to a duplicate route generated by Devise).